### PR TITLE
Fix shaped recipes not being craftable

### DIFF
--- a/src/main/java/net/blay09/mods/cookingforblockheads/container/ContainerRecipeBook.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/container/ContainerRecipeBook.java
@@ -116,15 +116,15 @@ public class ContainerRecipeBook extends Container {
 	}
 
 	public void setCraftMatrix(FoodRecipe recipe) {
-		if(recipe != null) {
-			for(SlotCraftMatrix previewSlot : craftMatrixSlots) {
-				previewSlot.setIngredient(null);
-				previewSlot.setEnabled(false);
-				if(!isClientSide) {
-					previewSlot.updateVisibleStacks();
-				}
+		for (SlotCraftMatrix previewSlot : craftMatrixSlots) {
+			previewSlot.setIngredient(null);
+			previewSlot.setEnabled(false);
+			if (!isClientSide) {
+				previewSlot.updateVisibleStacks();
 			}
+		}
 
+		if(recipe != null) {
 			isFurnaceRecipe = recipe.isSmeltingRecipe();
 			if(isFurnaceRecipe) {
 				craftMatrixSlots[4].setIngredient(recipe.getCraftMatrix().get(0));
@@ -155,11 +155,6 @@ public class ContainerRecipeBook extends Container {
 						craftMatrixSlots[i].updateVisibleStacks();
 					}
 				}
-			}
-		} else {
-			for(SlotCraftMatrix previewSlot : craftMatrixSlots) {
-				previewSlot.setIngredient(null);
-				previewSlot.setEnabled(false);
 			}
 		}
 	}

--- a/src/main/java/net/blay09/mods/cookingforblockheads/container/ContainerRecipeBook.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/container/ContainerRecipeBook.java
@@ -117,15 +117,16 @@ public class ContainerRecipeBook extends Container {
 
 	public void setCraftMatrix(FoodRecipe recipe) {
 		if(recipe != null) {
+			for(SlotCraftMatrix previewSlot : craftMatrixSlots) {
+				previewSlot.setIngredient(null);
+				previewSlot.setEnabled(false);
+				if(!isClientSide) {
+					previewSlot.updateVisibleStacks();
+				}
+			}
+
 			isFurnaceRecipe = recipe.isSmeltingRecipe();
 			if(isFurnaceRecipe) {
-				for(SlotCraftMatrix previewSlot : craftMatrixSlots) {
-					previewSlot.setIngredient(null);
-					previewSlot.setEnabled(false);
-					if(!isClientSide) {
-						previewSlot.updateVisibleStacks();
-					}
-				}
 				craftMatrixSlots[4].setIngredient(recipe.getCraftMatrix().get(0));
 				craftMatrixSlots[4].setEnabled(true);
 				if(!isClientSide) {
@@ -133,18 +134,21 @@ public class ContainerRecipeBook extends Container {
 				}
 			} else {
 				int offset = 0;
-				if (recipe.getCraftMatrix().size() <= 3) {
+				if (recipe.getRecipeWidth() == 1) {
+					// center column
+					offset += 1;
+				}
+				if (recipe.getRecipeHeight() == 1) {
+					// center row
 					offset += 3;
 				}
-				if(recipe.getCraftMatrix().size() == 1) {
-					offset++;
-				}
 				for (int i = 0; i < craftMatrix.getSizeInventory(); i++) {
-					int recipeIdx = i - offset;
-					if (recipeIdx >= 0 && recipeIdx < recipe.getCraftMatrix().size()) {
-						craftMatrixSlots[i].setIngredient(recipe.getCraftMatrix().get(recipeIdx));
-					} else {
-						craftMatrixSlots[i].setIngredient(null);
+					int origX = i % recipe.getRecipeWidth();
+					int origY = i / recipe.getRecipeWidth();
+					int targetIdx = origY * 3 + origX;
+					targetIdx += offset;
+					if (i < recipe.getCraftMatrix().size()) {
+						craftMatrixSlots[targetIdx].setIngredient(recipe.getCraftMatrix().get(i));
 					}
 					craftMatrixSlots[i].setEnabled(true);
 					if(!isClientSide) {

--- a/src/main/java/net/blay09/mods/cookingforblockheads/container/inventory/InventoryCraftBook.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/container/inventory/InventoryCraftBook.java
@@ -46,6 +46,10 @@ public class InventoryCraftBook extends InventoryCrafting {
             sourceInventorySlots[i] = -1;
         }
         ingredientLoop:for(int i = 0; i < ingredients.size(); i++) {
+            int origX = i % recipe.getRecipeWidth();
+            int origY = i / recipe.getRecipeWidth();
+            int targetIdx = origY * 3 + origX;
+
             if(ingredients.get(i) != null) {
                 sourceProviders.clear();
                 for(IKitchenItemProvider itemProvider : itemProviders) {
@@ -55,7 +59,7 @@ public class InventoryCraftBook extends InventoryCrafting {
                             ItemStack itemStack = providedStack.copy();
                             if(itemProvider.addToCraftingBuffer(itemStack)) {
                                 sourceProviders.add(itemProvider);
-                                setInventorySlotContents(i, itemStack);
+                                setInventorySlotContents(targetIdx, itemStack);
                                 continue ingredientLoop;
                             }
                         }
@@ -66,9 +70,9 @@ public class InventoryCraftBook extends InventoryCrafting {
                         ItemStack itemStack = inventories.get(j).getStackInSlot(k);
                         if (itemStack != null && ingredients.get(i).isValidItem(itemStack) && itemStack.stackSize - usedStackSize[j][k] > 0) {
                             usedStackSize[j][k]++;
-                            setInventorySlotContents(i, itemStack);
-                            sourceInventories[i] = j;
-                            sourceInventorySlots[i] = k;
+                            setInventorySlotContents(targetIdx, itemStack);
+                            sourceInventories[targetIdx] = j;
+                            sourceInventorySlots[targetIdx] = k;
                             continue ingredientLoop;
                         }
                     }

--- a/src/main/java/net/blay09/mods/cookingforblockheads/registry/food/FoodRecipe.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/registry/food/FoodRecipe.java
@@ -8,6 +8,8 @@ public abstract class FoodRecipe {
 
     protected List<FoodIngredient> craftMatrix;
     protected ItemStack outputItem;
+    protected int recipeWidth = 3;
+    protected int recipeHeight = 3;
 
     public List<FoodIngredient> getCraftMatrix() {
         return craftMatrix;
@@ -19,6 +21,14 @@ public abstract class FoodRecipe {
 
     public boolean isSmeltingRecipe() {
         return false;
+    }
+
+    public int getRecipeWidth() {
+        return recipeWidth;
+    }
+
+    public int getRecipeHeight() {
+        return recipeHeight;
     }
 
 }

--- a/src/main/java/net/blay09/mods/cookingforblockheads/registry/food/recipe/ShapedCraftingFood.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/registry/food/recipe/ShapedCraftingFood.java
@@ -11,12 +11,16 @@ public class ShapedCraftingFood extends FoodRecipe {
 
     public ShapedCraftingFood(ShapedRecipes recipe) {
         this.outputItem = recipe.getRecipeOutput();
-        craftMatrix = new ArrayList<>();
+        this.recipeWidth = recipe.recipeWidth;
+        this.recipeHeight = recipe.recipeHeight;
+        this.craftMatrix = new ArrayList<>();
 
         for(int i = 0; i < recipe.recipeItems.length; i++) {
             if(recipe.recipeItems[i] != null) {
                 boolean isToolItem = CookingRegistry.isToolItem(recipe.recipeItems[i]);
                 craftMatrix.add(new FoodIngredient(recipe.recipeItems[i].copy(), isToolItem));
+            } else {
+                craftMatrix.add(null);
             }
         }
     }

--- a/src/main/java/net/blay09/mods/cookingforblockheads/registry/food/recipe/ShapedCraftingFood.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/registry/food/recipe/ShapedCraftingFood.java
@@ -3,6 +3,7 @@ package net.blay09.mods.cookingforblockheads.registry.food.recipe;
 import net.blay09.mods.cookingforblockheads.registry.CookingRegistry;
 import net.blay09.mods.cookingforblockheads.registry.food.FoodIngredient;
 import net.blay09.mods.cookingforblockheads.registry.food.FoodRecipe;
+import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.ShapedRecipes;
 
 import java.util.ArrayList;
@@ -15,10 +16,10 @@ public class ShapedCraftingFood extends FoodRecipe {
         this.recipeHeight = recipe.recipeHeight;
         this.craftMatrix = new ArrayList<>();
 
-        for(int i = 0; i < recipe.recipeItems.length; i++) {
-            if(recipe.recipeItems[i] != null) {
-                boolean isToolItem = CookingRegistry.isToolItem(recipe.recipeItems[i]);
-                craftMatrix.add(new FoodIngredient(recipe.recipeItems[i].copy(), isToolItem));
+        for (ItemStack itemStack : recipe.recipeItems) {
+            if(itemStack != null) {
+                boolean isToolItem = CookingRegistry.isToolItem(itemStack);
+                craftMatrix.add(new FoodIngredient(itemStack.copy(), isToolItem));
             } else {
                 craftMatrix.add(null);
             }

--- a/src/main/java/net/blay09/mods/cookingforblockheads/registry/food/recipe/ShapedOreCraftingFood.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/registry/food/recipe/ShapedOreCraftingFood.java
@@ -25,17 +25,18 @@ public class ShapedOreCraftingFood extends FoodRecipe {
         }
         this.craftMatrix = new ArrayList<>();
 
-        for(int i = 0; i < recipe.getInput().length; i++) {
-            Object input = recipe.getInput()[i];
-            if (input == null) {
+        for(Object obj : recipe.getInput()) {
+            if (obj == null) {
                 craftMatrix.add(null);
                 continue;
             }
 
-            if(input instanceof ItemStack) {
-                craftMatrix.add(new FoodIngredient((ItemStack) input, false));
-            } else if(input instanceof List) {
-                craftMatrix.add(new FoodIngredient(((List<ItemStack>) input).toArray(new ItemStack[((List<ItemStack>) input).size()]), false));
+            if (obj instanceof ItemStack) {
+                craftMatrix.add(new FoodIngredient((ItemStack) obj, false));
+            } else if (obj instanceof List) {
+                // TODO: cast warning
+                List<ItemStack> inputList = (List<ItemStack>) obj;
+                craftMatrix.add(new FoodIngredient(inputList.toArray(new ItemStack[inputList.size()]), false));
             }
         }
     }

--- a/src/main/java/net/blay09/mods/cookingforblockheads/registry/food/recipe/ShapedOreCraftingFood.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/registry/food/recipe/ShapedOreCraftingFood.java
@@ -5,6 +5,7 @@ import net.blay09.mods.cookingforblockheads.registry.food.FoodRecipe;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.ShapedOreRecipe;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -12,10 +13,22 @@ public class ShapedOreCraftingFood extends FoodRecipe {
 
     public ShapedOreCraftingFood(ShapedOreRecipe recipe) {
         this.outputItem = recipe.getRecipeOutput();
+        try {
+            Field widthField = ShapedOreRecipe.class.getDeclaredField("width");
+            widthField.setAccessible(true);
+            this.recipeWidth = (int) widthField.get(recipe);
+            Field heightField = ShapedOreRecipe.class.getDeclaredField("height");
+            heightField.setAccessible(true);
+            this.recipeHeight = (int) heightField.get(recipe);
+        } catch (IllegalAccessException | NoSuchFieldException e) {
+            e.printStackTrace();
+        }
         this.craftMatrix = new ArrayList<>();
+
         for(int i = 0; i < recipe.getInput().length; i++) {
             Object input = recipe.getInput()[i];
             if (input == null) {
+                craftMatrix.add(null);
                 continue;
             }
 

--- a/src/main/java/net/blay09/mods/cookingforblockheads/registry/food/recipe/ShapelessCraftingFood.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/registry/food/recipe/ShapelessCraftingFood.java
@@ -15,10 +15,12 @@ public class ShapelessCraftingFood extends FoodRecipe {
         this.recipeWidth = Math.min(3, recipe.getRecipeSize());
         this.recipeHeight = (int) Math.ceil((double) recipe.getRecipeSize() / 3);
         this.craftMatrix = new ArrayList<>();
-        for(int i = 0; i < recipe.recipeItems.size(); i++) {
-            if (recipe.recipeItems.get(i) != null) {
-                boolean isToolItem = CookingRegistry.isToolItem((ItemStack) recipe.recipeItems.get(i));
-                craftMatrix.add(new FoodIngredient(((ItemStack) recipe.recipeItems.get(i)).copy(), isToolItem));
+
+        for (Object obj : recipe.recipeItems) {
+            if (obj != null) {
+                ItemStack itemStack = (ItemStack) obj;
+                boolean isToolItem = CookingRegistry.isToolItem(itemStack);
+                craftMatrix.add(new FoodIngredient(itemStack.copy(), isToolItem));
             }
         }
     }

--- a/src/main/java/net/blay09/mods/cookingforblockheads/registry/food/recipe/ShapelessCraftingFood.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/registry/food/recipe/ShapelessCraftingFood.java
@@ -12,6 +12,8 @@ public class ShapelessCraftingFood extends FoodRecipe {
 
     public ShapelessCraftingFood(ShapelessRecipes recipe) {
         this.outputItem = recipe.getRecipeOutput();
+        this.recipeWidth = Math.min(3, recipe.getRecipeSize());
+        this.recipeHeight = (int) Math.ceil((double) recipe.getRecipeSize() / 3);
         this.craftMatrix = new ArrayList<>();
         for(int i = 0; i < recipe.recipeItems.size(); i++) {
             if (recipe.recipeItems.get(i) != null) {

--- a/src/main/java/net/blay09/mods/cookingforblockheads/registry/food/recipe/ShapelessOreCraftingFood.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/registry/food/recipe/ShapelessOreCraftingFood.java
@@ -1,7 +1,6 @@
 package net.blay09.mods.cookingforblockheads.registry.food.recipe;
 
 import net.blay09.mods.cookingforblockheads.registry.CookingRegistry;
-import net.blay09.mods.cookingforblockheads.registry.food.*;
 import net.blay09.mods.cookingforblockheads.registry.food.FoodIngredient;
 import net.blay09.mods.cookingforblockheads.registry.food.FoodRecipe;
 import net.minecraft.item.ItemStack;
@@ -17,21 +16,22 @@ public class ShapelessOreCraftingFood extends FoodRecipe {
         this.recipeWidth = Math.min(3, recipe.getRecipeSize());
         this.recipeHeight = (int) Math.ceil((double) recipe.getRecipeSize() / 3);
         this.craftMatrix = new ArrayList<>();
-        for(int i = 0; i < recipe.getInput().size(); i++) {
-            Object input = recipe.getInput().get(i);
 
-            if (input == null) {
+        for (Object obj : recipe.getInput()) {
+            if (obj == null) {
                 continue;
             }
 
-            if(input instanceof ItemStack) {
-                boolean isToolItem = CookingRegistry.isToolItem((ItemStack) input);
-                craftMatrix.add(new FoodIngredient(((ItemStack) input), isToolItem));
-            } else if(input instanceof ArrayList) {
-                List<ItemStack> list = (List<ItemStack>) input;
+            if (obj instanceof ItemStack) {
+                ItemStack itemStack = (ItemStack) obj;
+                boolean isToolItem = CookingRegistry.isToolItem(itemStack);
+                craftMatrix.add(new FoodIngredient(itemStack, isToolItem));
+            } else if (obj instanceof ArrayList) {
+                // TODO: cast warning
+                List<ItemStack> list = (List<ItemStack>) obj;
                 boolean toolFound = false;
-                for(int j = 0; j < list.size(); j++) {
-                    if(CookingRegistry.isToolItem(list.get(j))) {
+                for (ItemStack itemStack : list) {
+                    if (CookingRegistry.isToolItem(itemStack)) {
                         toolFound = true;
                     }
                 }

--- a/src/main/java/net/blay09/mods/cookingforblockheads/registry/food/recipe/ShapelessOreCraftingFood.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/registry/food/recipe/ShapelessOreCraftingFood.java
@@ -14,6 +14,8 @@ public class ShapelessOreCraftingFood extends FoodRecipe {
 
     public ShapelessOreCraftingFood(ShapelessOreRecipe recipe) {
         this.outputItem = recipe.getRecipeOutput();
+        this.recipeWidth = Math.min(3, recipe.getRecipeSize());
+        this.recipeHeight = (int) Math.ceil((double) recipe.getRecipeSize() / 3);
         this.craftMatrix = new ArrayList<>();
         for(int i = 0; i < recipe.getInput().size(); i++) {
             Object input = recipe.getInput().get(i);


### PR DESCRIPTION
Based on upstream commits https://github.com/ModdingForBlockheads/CookingForBlockheads/commit/a0cb729e050bbe27a38169fee0976e8f9b5d3463, https://github.com/ModdingForBlockheads/CookingForBlockheads/commit/516b5f0a98ed720358bf1e4ff5fbd0821a79b42b, and https://github.com/ModdingForBlockheads/CookingForBlockheads/commit/b34525b5e5c55e880b98602f666d39cd7e5cc45f.

1. Insert `craftMatrix.add(null);` if crafting matrix has null input.
2. Add `getRecipeWidth` method so that recipebook can know recipes' width. e.g.

Potato Chips:
```
"k", "X"
```
Potato Strips:
```
"k"
"X"
```
where k = knife, X = potato
Note that both recipes don't have null inputs and `craftMatrix`es are represented as
```
["Knife", "Potato"]
```

3. Add `getRecipeHeight` method, which is used only for client rendering.

Partially addresses #2.

And great thanks to Mitch.