### PR TITLE
Fix inventory desync when opening cooking table

### DIFF
--- a/src/main/java/net/blay09/mods/cookingforblockheads/container/ContainerRecipeBook.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/container/ContainerRecipeBook.java
@@ -116,15 +116,14 @@ public class ContainerRecipeBook extends Container {
     }
 
     public void setCraftMatrix(FoodRecipe recipe) {
-        for (SlotCraftMatrix previewSlot : craftMatrixSlots) {
-            previewSlot.setIngredient(null);
-            previewSlot.setEnabled(false);
-            if (!isClientSide) {
-                previewSlot.updateVisibleStacks();
-            }
-        }
-
         if (recipe != null) {
+            for (SlotCraftMatrix previewSlot : craftMatrixSlots) {
+                previewSlot.setIngredient(null);
+                previewSlot.setEnabled(false);
+                if (!isClientSide) {
+                    previewSlot.updateVisibleStacks();
+                }
+            }
             isFurnaceRecipe = recipe.isSmeltingRecipe();
             if (isFurnaceRecipe) {
                 craftMatrixSlots[4].setIngredient(recipe.getCraftMatrix().get(0));


### PR DESCRIPTION
The goal is to fix GTNewHorizons/GT-New-Horizons-Modpack#10396.

I've figured that the reason the bug occurs is when SlotCraftMatrix.java calls `updateVisibleStacks()`, it overrides the player's armor slots on the client side (see TODO markers) - not sure if `update()` does it too.

What was happening was the server was sending a inventory sync packet before the client even knew the GUI was open, wiping the armor slots. This patch removes the sync when the GUI is constructed (as the slots in question are always going to be null).