### PR TITLE
Fix: TileEntity migration from old savefiles

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,2 +1,0 @@
-minecraft.version=1.7.10
-forge.version=10.13.4.1614-1.7.10

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,16 +21,19 @@ forgeVersion = 10.13.4.1614
 # Do you need to test how your custom blocks interacts with a player that is not the owner? -> leave name empty
 developmentEnvironmentUserName = Developer
 
-# Define a source file of your project with:
+# Generate a class with String fields for the mod id, name, version and group name named with the fields below
+generateGradleTokenClass = net.blay09.mods.cookingforblockheads.Tags
+gradleTokenModId =
+gradleTokenModName =
+gradleTokenVersion = VERSION
+gradleTokenGroupName =
+# [DEPRECATED]
+# Multiple source files can be defined here by providing a comma-seperated list: Class1.java,Class2.java,Class3.java
 # public static final String VERSION = "GRADLETOKEN_VERSION";
-# The string's content will be replaced with your mods version when compiled. You should use this to specify your mod's
+# The string's content will be replaced with your mod's version when compiled. You should use this to specify your mod's
 # version in @Mod([...], version = VERSION, [...])
 # Leave these properties empty to skip individual token replacements
-replaceGradleTokenInFile = CookingForBlockheads.java
-gradleTokenModId = GRADLETOKEN_MODID
-gradleTokenModName = GRADLETOKEN_MODNAME
-gradleTokenVersion = GRADLETOKEN_VERSION
-gradleTokenGroupName = 
+replaceGradleTokenInFile =
 
 # In case your mod provides an API for other mods to implement you may declare its package here. Otherwise, you can
 # leave this property empty.

--- a/src/main/java/net/blay09/mods/cookingforblockheads/CommonProxy.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/CommonProxy.java
@@ -19,6 +19,7 @@ import net.blay09.mods.cookingforblockheads.utils.DyeUtils;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.oredict.ShapedOreRecipe;
 
 import cpw.mods.fml.common.Loader;
@@ -34,6 +35,13 @@ public class CommonProxy {
     private boolean mineTweakerHasPostReload;
 
     public void preInit(FMLPreInitializationEvent event) {}
+
+    private static void registerTileEntity(Class<? extends TileEntity> tileEntityClass, String id) {
+        // Register with the old modid to ensure data doesn't get lost on world conversion
+        GameRegistry.registerTileEntity(tileEntityClass, "cookingbook:" + id);
+        // Newest ID must be last to ensure the correct canonical mapping
+        GameRegistry.registerTileEntity(tileEntityClass, CookingForBlockheads.MOD_ID + ":" + id);
+    }
 
     public void init(FMLInitializationEvent event) {
         GameRegistry.registerItem(CookingForBlockheads.itemRecipeBook, "recipebook");
@@ -94,16 +102,16 @@ public class CommonProxy {
                 "toaster",
                 new Object[] { "toaster", false });
 
-        GameRegistry.registerTileEntity(TileOven.class, CookingForBlockheads.MOD_ID + ":cookingoven");
-        GameRegistry.registerTileEntity(TileFridge.class, CookingForBlockheads.MOD_ID + ":fridge");
-        GameRegistry.registerTileEntity(TileCounter.class, CookingForBlockheads.MOD_ID + ":counter");
-        GameRegistry.registerTileEntity(TileCounterCorner.class, CookingForBlockheads.MOD_ID + ":countercorner");
-        GameRegistry.registerTileEntity(TileCabinet.class, CookingForBlockheads.MOD_ID + ":cabinet");
-        GameRegistry.registerTileEntity(TileCabinetCorner.class, CookingForBlockheads.MOD_ID + ":cabinetcorner");
-        GameRegistry.registerTileEntity(TileToolRack.class, CookingForBlockheads.MOD_ID + ":toolrack");
-        GameRegistry.registerTileEntity(TileSink.class, CookingForBlockheads.MOD_ID + ":sink");
-        GameRegistry.registerTileEntity(TileCookingTable.class, CookingForBlockheads.MOD_ID + ":cookingtable");
-        GameRegistry.registerTileEntity(TileToaster.class, CookingForBlockheads.MOD_ID + ":toaster");
+        registerTileEntity(TileOven.class, "cookingoven");
+        registerTileEntity(TileFridge.class, "fridge");
+        registerTileEntity(TileCounter.class, "counter");
+        registerTileEntity(TileCounterCorner.class, "countercorner");
+        registerTileEntity(TileCabinet.class, "cabinet");
+        registerTileEntity(TileCabinetCorner.class, "cabinetcorner");
+        registerTileEntity(TileToolRack.class, "toolrack");
+        registerTileEntity(TileSink.class, "sink");
+        registerTileEntity(TileCookingTable.class, "cookingtable");
+        registerTileEntity(TileToaster.class, "toaster");
 
         // #NoFilter Edition
         if (CookingConfig.enableNoFilter) {

--- a/src/main/java/net/blay09/mods/cookingforblockheads/CookingForBlockheads.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/CookingForBlockheads.java
@@ -35,9 +35,9 @@ import cpw.mods.fml.common.registry.GameRegistry;
 @Mod(modid = CookingForBlockheads.MOD_ID, version = CookingForBlockheads.VERSION, name = CookingForBlockheads.NAME)
 public class CookingForBlockheads {
 
-    public static final String VERSION = "GRADLETOKEN_VERSION";
-    public static final String NAME = "GRADLETOKEN_MODNAME";
-    public static final String MOD_ID = "GRADLETOKEN_MODID";
+    public static final String VERSION = Tags.VERSION;
+    public static final String NAME = "Cooking For Blockheads";
+    public static final String MOD_ID = "cookingforblockheads";
 
     public static CreativeTabs creativeTab = new CreativeTabs(MOD_ID) {
 


### PR DESCRIPTION
There were block&item mappings but not TileEntity mappings which meant the contents of fridges etc. were lost.
I tested this PR with a savefile from the Curse version and every block seemed to migrate correctly with the fix.