### PR TITLE
Compatibility with old versions of Spice of Life

### DIFF
--- a/src/main/java/net/blay09/mods/cookingforblockheads/CommonProxy.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/CommonProxy.java
@@ -1,6 +1,7 @@
 package net.blay09.mods.cookingforblockheads;
 
 import net.blay09.mods.cookingforblockheads.compat.VanillaAddon;
+import net.blay09.mods.cookingforblockheads.container.comparator.ComparatorSoL;
 import net.blay09.mods.cookingforblockheads.item.ItemBlockFridge;
 import net.blay09.mods.cookingforblockheads.item.ItemBlockGenericKitchen;
 import net.blay09.mods.cookingforblockheads.network.NetworkHandler;
@@ -30,6 +31,7 @@ import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.event.FMLServerStartedEvent;
 import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.common.registry.GameRegistry;
+import squeek.spiceoflife.foodtracker.FoodHistory;
 
 public class CommonProxy {
 
@@ -470,6 +472,14 @@ public class CommonProxy {
     public void postInit(FMLPostInitializationEvent event) {
         if (CookingConfig.moduleVanilla) {
             new VanillaAddon();
+        }
+        if (Loader.isModLoaded("SpiceOfLife")) {
+            try {
+                FoodHistory.class.getDeclaredMethod("getHistory");
+                ComparatorSoL.spiceCompat = true;
+            } catch (NoSuchMethodException e) {
+                ComparatorSoL.spiceCompat = false;
+            }
         }
 
         try {

--- a/src/main/java/net/blay09/mods/cookingforblockheads/container/comparator/ComparatorSoL.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/container/comparator/ComparatorSoL.java
@@ -1,18 +1,23 @@
 package net.blay09.mods.cookingforblockheads.container.comparator;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Comparator;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 
 import squeek.spiceoflife.ModConfig;
+import squeek.spiceoflife.foodtracker.FoodEaten;
 import squeek.spiceoflife.foodtracker.FoodHistory;
+import squeek.spiceoflife.foodtracker.foodqueue.FoodQueue;
 import squeek.spiceoflife.helpers.FoodHelper;
 
 public class ComparatorSoL implements Comparator<ItemStack> {
 
     private final ComparatorName fallback = new ComparatorName();
     private final EntityPlayer entityPlayer;
+    public static boolean spiceCompat = false;
 
     public ComparatorSoL(EntityPlayer entityPlayer) {
         this.entityPlayer = entityPlayer;
@@ -40,9 +45,31 @@ public class ComparatorSoL implements Comparator<ItemStack> {
         } else if (!isFoodSecond) {
             return -1;
         }
-
-        boolean everEatenFirstFood = foodHistory.hasEverEaten(o1);
-        boolean everEatenSecondFood = foodHistory.hasEverEaten(o2);
+        boolean everEatenFirstFood = false, everEatenSecondFood = false;
+        if (!spiceCompat) {
+            everEatenFirstFood = foodHistory.hasEverEaten(o1);
+            everEatenSecondFood = foodHistory.hasEverEaten(o2);
+        } else {
+            // Older versions of Spice of Life don't have full food history, and therefore don't have a hasEverEaten
+            // This has similar, though not identical, behavior for those older versions.
+            try {
+                Method method = foodHistory.getClass().getDeclaredMethod("getHistory");
+                Object history = method.invoke(foodHistory);
+                FoodQueue foodQueue = (FoodQueue) history;
+                for (FoodEaten foodEaten : foodQueue) {
+                    if (foodEaten.itemStack.isItemEqual(o1)) {
+                        everEatenFirstFood = true;
+                    }
+                    if (foodEaten.itemStack.isItemEqual(o2)) {
+                        everEatenSecondFood = true;
+                    }
+                }
+            } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException ex) {
+                System.out.println("Spice of Life compatibility failed");
+                System.out.println(ex.getMessage());
+                return -1;
+            }
+        }
         if (!everEatenFirstFood && !everEatenSecondFood) {
             return fallback.compare(o1, o2);
         } else if (!everEatenFirstFood) {


### PR DESCRIPTION
This patch adds compatibility with the original Spice of Life versions with diminishing returns, which is still used in Blightfall. 

Tested with Spice of Life 1.3.11