### PR TITLE
Toaster is no longer floating

### DIFF
--- a/src/main/java/net/blay09/mods/cookingforblockheads/block/BlockToaster.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/block/BlockToaster.java
@@ -4,6 +4,7 @@ import net.blay09.mods.cookingforblockheads.CookingForBlockheads;
 import net.blay09.mods.cookingforblockheads.client.render.block.ToasterBlockRenderer;
 import net.blay09.mods.cookingforblockheads.registry.CookingRegistry;
 import net.blay09.mods.cookingforblockheads.tile.TileToaster;
+import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.EntityLivingBase;
@@ -11,8 +12,10 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.MathHelper;
+import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
 public class BlockToaster extends BlockBaseKitchen {
@@ -31,8 +34,24 @@ public class BlockToaster extends BlockBaseKitchen {
     public void onBlockAdded(World worldIn, int x, int y, int z) {
         super.onBlockAdded(worldIn, x, y, z);
         findOrientation(worldIn, x, y, z);
+        if (worldIn.getBlock(x, y - 1, z) == CookingForBlockheads.blockCounterCorner || worldIn.getBlock(x, y - 1, z) == CookingForBlockheads.blockCounter)
+        {
+            setBlockBounds(0.275f, -.0625f, 0.275f, 0.725f, 0.3375f, 0.725f);
+        }
     }
 
+    @Override
+    public void onNeighborBlockChange(World world, int x, int y, int z, Block neighborBlock) {
+        if (world.getBlock(x, y - 1, z) == CookingForBlockheads.blockCounterCorner || world.getBlock(x, y - 1, z) == CookingForBlockheads.blockCounter)
+        {
+            setBlockBounds(0.275f, -.0625f, 0.275f, 0.725f, 0.3375f, 0.725f);
+        }
+        else
+        {
+            setBlockBounds(0.275f, 0f, 0.275f, 0.725f, 0.4f, 0.725f);
+        }
+    }
+    
     @Override
     public boolean isOpaqueCube() {
         return false;

--- a/src/main/java/net/blay09/mods/cookingforblockheads/block/BlockToaster.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/block/BlockToaster.java
@@ -12,10 +12,8 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.MathHelper;
-import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
 public class BlockToaster extends BlockBaseKitchen {
@@ -34,24 +32,22 @@ public class BlockToaster extends BlockBaseKitchen {
     public void onBlockAdded(World worldIn, int x, int y, int z) {
         super.onBlockAdded(worldIn, x, y, z);
         findOrientation(worldIn, x, y, z);
-        if (worldIn.getBlock(x, y - 1, z) == CookingForBlockheads.blockCounterCorner || worldIn.getBlock(x, y - 1, z) == CookingForBlockheads.blockCounter)
-        {
+        if (worldIn.getBlock(x, y - 1, z) == CookingForBlockheads.blockCounterCorner
+                || worldIn.getBlock(x, y - 1, z) == CookingForBlockheads.blockCounter) {
             setBlockBounds(0.275f, -.0625f, 0.275f, 0.725f, 0.3375f, 0.725f);
         }
     }
 
     @Override
     public void onNeighborBlockChange(World world, int x, int y, int z, Block neighborBlock) {
-        if (world.getBlock(x, y - 1, z) == CookingForBlockheads.blockCounterCorner || world.getBlock(x, y - 1, z) == CookingForBlockheads.blockCounter)
-        {
+        if (world.getBlock(x, y - 1, z) == CookingForBlockheads.blockCounterCorner
+                || world.getBlock(x, y - 1, z) == CookingForBlockheads.blockCounter) {
             setBlockBounds(0.275f, -.0625f, 0.275f, 0.725f, 0.3375f, 0.725f);
-        }
-        else
-        {
+        } else {
             setBlockBounds(0.275f, 0f, 0.275f, 0.725f, 0.4f, 0.725f);
         }
     }
-    
+
     @Override
     public boolean isOpaqueCube() {
         return false;

--- a/src/main/java/net/blay09/mods/cookingforblockheads/client/render/tile/TileEntityToasterRenderer.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/client/render/tile/TileEntityToasterRenderer.java
@@ -24,8 +24,11 @@ public class TileEntityToasterRenderer extends TileEntitySpecialRenderer {
     public void renderTileEntityAt(TileEntity tileEntity, double x, double y, double z, float delta) {
         GL11.glPushMatrix();
         int metadata = 0;
+        boolean counterBelow = false;
         if (tileEntity.hasWorldObj()) {
             metadata = tileEntity.getBlockMetadata();
+            counterBelow = tileEntity.getWorldObj().getBlock(tileEntity.xCoord, tileEntity.yCoord - 1, tileEntity.zCoord) == CookingForBlockheads.blockCounter ||
+                    tileEntity.getWorldObj().getBlock(tileEntity.xCoord, tileEntity.yCoord - 1, tileEntity.zCoord) == CookingForBlockheads.blockCounterCorner;
         } else {
             GL11.glScalef(2f, 2f, 2f);
             GL11.glTranslatef(0, 0.25f, 0);
@@ -38,6 +41,10 @@ public class TileEntityToasterRenderer extends TileEntitySpecialRenderer {
         GL11.glColor4f(1f, 1f, 1f, 1f);
         GL11.glTranslatef((float) x, (float) y, (float) z);
         GL11.glTranslatef(0.5f, 0.065f, 0.5f);
+        if (counterBelow)
+        {
+            GL11.glTranslatef(0f, -0.0625F, 0f);
+        }
         float angle = RenderUtils.getAngle(metadata);
         GL11.glRotatef(angle, 0f, 1f, 0f);
         GL11.glRotatef(180f, 0f, 0f, 1f);

--- a/src/main/java/net/blay09/mods/cookingforblockheads/client/render/tile/TileEntityToasterRenderer.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/client/render/tile/TileEntityToasterRenderer.java
@@ -27,8 +27,11 @@ public class TileEntityToasterRenderer extends TileEntitySpecialRenderer {
         boolean counterBelow = false;
         if (tileEntity.hasWorldObj()) {
             metadata = tileEntity.getBlockMetadata();
-            counterBelow = tileEntity.getWorldObj().getBlock(tileEntity.xCoord, tileEntity.yCoord - 1, tileEntity.zCoord) == CookingForBlockheads.blockCounter ||
-                    tileEntity.getWorldObj().getBlock(tileEntity.xCoord, tileEntity.yCoord - 1, tileEntity.zCoord) == CookingForBlockheads.blockCounterCorner;
+            counterBelow = tileEntity.getWorldObj()
+                    .getBlock(tileEntity.xCoord, tileEntity.yCoord - 1, tileEntity.zCoord)
+                    == CookingForBlockheads.blockCounter
+                    || tileEntity.getWorldObj().getBlock(tileEntity.xCoord, tileEntity.yCoord - 1, tileEntity.zCoord)
+                            == CookingForBlockheads.blockCounterCorner;
         } else {
             GL11.glScalef(2f, 2f, 2f);
             GL11.glTranslatef(0, 0.25f, 0);
@@ -41,8 +44,7 @@ public class TileEntityToasterRenderer extends TileEntitySpecialRenderer {
         GL11.glColor4f(1f, 1f, 1f, 1f);
         GL11.glTranslatef((float) x, (float) y, (float) z);
         GL11.glTranslatef(0.5f, 0.065f, 0.5f);
-        if (counterBelow)
-        {
+        if (counterBelow) {
             GL11.glTranslatef(0f, -0.0625F, 0f);
         }
         float angle = RenderUtils.getAngle(metadata);


### PR DESCRIPTION
Toaster now doesn't float when it's on CookingForBlockheads counters.
Small little change, but as I'm doing a new play-through this annoyed me more than it should...

Before:
![image](https://github.com/user-attachments/assets/62610b8e-6d49-4518-a2ed-870b68d41a0e)

After:
![image](https://github.com/user-attachments/assets/d9a26049-77f0-47d3-9a2c-1cb569f5d679)
