### PR TITLE
Fixed baguette dough crafting

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.30'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.33'
 }
 
 

--- a/src/main/java/net/blay09/mods/cookingforblockheads/container/inventory/InventoryCraftBook.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/container/inventory/InventoryCraftBook.java
@@ -83,7 +83,12 @@ public class InventoryCraftBook extends InventoryCrafting {
                 }
             }
         }
+
         currentRecipe = CookingRegistry.findMatchingFoodRecipe(this, player.worldObj);
+        if (currentRecipe != null && currentRecipe.getRecipeOutput() != recipe.getOutputItem()) {
+            currentRecipe = null;
+        }
+
         return currentRecipe;
     }
 


### PR DESCRIPTION
If you take a stack of dough and try to shift click baguette dough in the cooking table it creates 21 baguette dough plus 1 bun shaped dough but it should only craft 21 baguette dough with no other products. 

I solved this bug by doing a simple check to see if the recipe that we are trying to craft doesn't line up with the recipe that is going to be crafted then don't craft it. Simple right?