### PR TITLE
Tweak StorageDrawer Compat and add JABBA Compatibility

### DIFF
--- a/src/main/java/net/blay09/mods/cookingforblockheads/CommonProxy.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/CommonProxy.java
@@ -489,6 +489,11 @@ public class CommonProxy {
                     "StorageDrawers",
                     "net.blay09.mods.cookingforblockheads.compat.StorageDrawersAddon");
         }
+        if (CookingConfig.moduleJabba) {
+            event.buildSoftDependProxy(
+                    "JABBA",
+                    "net.blay09.mods.cookingforblockheads.compat.JabbaAddon");
+        }
         if (CookingConfig.moduleDreamcraft) {
             event.buildSoftDependProxy("dreamcraft", "net.blay09.mods.cookingforblockheads.compat.DreamcraftAddon");
         }

--- a/src/main/java/net/blay09/mods/cookingforblockheads/CommonProxy.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/CommonProxy.java
@@ -490,9 +490,7 @@ public class CommonProxy {
                     "net.blay09.mods.cookingforblockheads.compat.StorageDrawersAddon");
         }
         if (CookingConfig.moduleJabba) {
-            event.buildSoftDependProxy(
-                    "JABBA",
-                    "net.blay09.mods.cookingforblockheads.compat.JabbaAddon");
+            event.buildSoftDependProxy("JABBA", "net.blay09.mods.cookingforblockheads.compat.JabbaAddon");
         }
         if (CookingConfig.moduleDreamcraft) {
             event.buildSoftDependProxy("dreamcraft", "net.blay09.mods.cookingforblockheads.compat.DreamcraftAddon");

--- a/src/main/java/net/blay09/mods/cookingforblockheads/CookingConfig.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/CookingConfig.java
@@ -26,6 +26,7 @@ public class CookingConfig {
     public static boolean moduleEnviroMine;
     public static boolean moduleAppleCore;
     public static boolean moduleStorageDrawers;
+    public static boolean moduleJabba;
     public static boolean moduleDreamcraft;
     public static boolean moduleGrectech5U;
     public static boolean usePamsToast;
@@ -93,6 +94,7 @@ public class CookingConfig {
         moduleEnviroMine = config.getBoolean("EnviroMine", "modules", true, "Multiblock Kitchen Support (Freezer)");
         moduleAppleCore = config.getBoolean("AppleCore", "modules", true, "Dynamic Food Values");
         moduleStorageDrawers = config.getBoolean("StorageDrawers", "modules", true, "StorageDrawers");
+        moduleJabba = config.getBoolean("Jabba", "modules", true, "Jabba");
         moduleDreamcraft = config.getBoolean("Dreamcraft", "modules", true, "Dreamcraft");
         moduleGrectech5U = config.getBoolean("Gregtech5U", "modules", true, "Gregtech5U");
         usePamsToast = config.getBoolean(

--- a/src/main/java/net/blay09/mods/cookingforblockheads/compat/JabbaAddon.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/compat/JabbaAddon.java
@@ -1,0 +1,13 @@
+package net.blay09.mods.cookingforblockheads.compat;
+
+import net.blay09.mods.cookingforblockheads.KitchenMultiBlock;
+import net.minecraftforge.common.MinecraftForge;
+
+public class JabbaAddon {
+
+    public JabbaAddon() {
+        KitchenMultiBlock.tileEntityWrappers
+                .put("mcp.mobius.betterbarrels.common.blocks.TileEntityBarrel", SimpleStorageProvider.class);
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+}

--- a/src/main/java/net/blay09/mods/cookingforblockheads/compat/StorageDrawersAddon.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/compat/StorageDrawersAddon.java
@@ -8,10 +8,12 @@ import cpw.mods.fml.common.registry.GameRegistry;
 public class StorageDrawersAddon {
 
     public StorageDrawersAddon() {
-        KitchenMultiBlock.tileEntityWrappers
-                .put("com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawersStandard", SimpleStorageProvider.class);
-        KitchenMultiBlock.tileEntityWrappers
-                .put("com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityController", SimpleStorageProvider.class);
+        KitchenMultiBlock.tileEntityWrappers.put(
+                "com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawersStandard",
+                SimpleStorageProvider.class);
+        KitchenMultiBlock.tileEntityWrappers.put(
+                "com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityController",
+                SimpleStorageProvider.class);
 
         KitchenMultiBlock.registerConnectorBlock(GameRegistry.findBlock("StorageDrawers", "trim"));
         MinecraftForge.EVENT_BUS.register(this);

--- a/src/main/java/net/blay09/mods/cookingforblockheads/compat/StorageDrawersAddon.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/compat/StorageDrawersAddon.java
@@ -1,9 +1,6 @@
 package net.blay09.mods.cookingforblockheads.compat;
 
 import net.blay09.mods.cookingforblockheads.KitchenMultiBlock;
-import net.blay09.mods.cookingforblockheads.api.kitchen.IKitchenStorageProvider;
-import net.minecraft.inventory.IInventory;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.MinecraftForge;
 
 import cpw.mods.fml.common.registry.GameRegistry;
@@ -12,8 +9,10 @@ public class StorageDrawersAddon {
 
     public StorageDrawersAddon() {
         KitchenMultiBlock.tileEntityWrappers
-                .put("com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawersStandard", DrawerWrapper.class);
                 .put("com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawersStandard", SimpleStorageProvider.class);
+        KitchenMultiBlock.tileEntityWrappers
+                .put("com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityController", SimpleStorageProvider.class);
+
         KitchenMultiBlock.registerConnectorBlock(GameRegistry.findBlock("StorageDrawers", "trim"));
         MinecraftForge.EVENT_BUS.register(this);
     }

--- a/src/main/java/net/blay09/mods/cookingforblockheads/compat/StorageDrawersAddon.java
+++ b/src/main/java/net/blay09/mods/cookingforblockheads/compat/StorageDrawersAddon.java
@@ -13,21 +13,8 @@ public class StorageDrawersAddon {
     public StorageDrawersAddon() {
         KitchenMultiBlock.tileEntityWrappers
                 .put("com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawersStandard", DrawerWrapper.class);
+                .put("com.jaquadro.minecraft.storagedrawers.block.tile.TileEntityDrawersStandard", SimpleStorageProvider.class);
         KitchenMultiBlock.registerConnectorBlock(GameRegistry.findBlock("StorageDrawers", "trim"));
         MinecraftForge.EVENT_BUS.register(this);
-    }
-
-    public static class DrawerWrapper implements IKitchenStorageProvider {
-
-        TileEntity tile;
-
-        public DrawerWrapper(TileEntity tile) {
-            this.tile = tile;
-        }
-
-        @Override
-        public IInventory getInventory() {
-            return (IInventory) tile;
-        }
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17339

This PR does a few things:

1. Previously storage drawers could form part of the Kitchen Multiblock, but not drawer controllers which was a little _counter_-intuitive (excuse the pun).  Drawer controllers now connect as part of the Kitchen, along with drawers and also trim.
2. Refactor `StorageDrawersAddon` to use the previously unused `SimpleStorageProvider` instead of a bespoke wrapper. This provider works for any tile entities that implement `IInventory`.
3. Add JABBA Barrel compatibility to the Kitchen Multiblock.

Changes have been tested in the latest Nightly.

![image](https://github.com/user-attachments/assets/4577142a-b104-4215-98da-18a500f57f67)
